### PR TITLE
Prevent overwriting with empty values

### DIFF
--- a/src/CSS_Vars.php
+++ b/src/CSS_Vars.php
@@ -99,7 +99,7 @@ class CSS_Vars {
 			foreach ( $args['css_vars'] as $css_var ) {
 				if ( isset( $css_var[2] ) && is_array( $val ) && isset( $val[ $css_var[2] ] ) ) {
 					$this->vars[ $css_var[0] ] = str_replace( '$', $val[ $css_var[2] ], $css_var[1] );
-				} else {
+				} else if ( ! isset( $css_var[2] ) && ! is_array( $val ) ) {
 					$this->vars[ $css_var[0] ] = str_replace( '$', $val, $css_var[1] );
 				}
 			}


### PR DESCRIPTION
It took me quite a while to understand why the CSS Vars module outputs strange or empty values when using it with fields that have multiple controls such as "typo" and "multicolor".
Lets take this example:

```
Kirki::add_field('sage', array(
            'type'      => 'multicolor',
            'settings'  => 'header_colors',
            'label'     => esc_attr__( 'Colors', 'textdomain' ),
            'section'   => 'header_typo',
            'default'   => [
                'primary'   => '#333',
                'secondary' => '#fff',
            ],
            'choices'   => [
                'primary'       => esc_attr__( 'Primary', 'textdomain' ),
                'secondary' => esc_attr__( 'Secondary', 'textdomain'),
            ],
            'transport' => 'auto',
            'css_vars'        => array(
                array( '--color-primary', '$', 'primary' ),
                array( '--color-secondary', '$', 'secondary' ),
            ),
        ));
```
It should output something like
````
:root {
    --color-primary: #123456;
    --color-secondary: #654321;
}
````
However whatever I tried with the settings above I just got the output:
````
:root {
    --color-primary:;
    --color-secondary:;
}
````
Looking at the functions generating the output I got the expression (and testet it) that the loop is calling each field multiple times. The first time the correct output is generated as `$val` is a correct array and the setter for 3 arguments is used:
`$this->vars[ $css_var[0] ] = str_replace( '$', $val[ $css_var[2] ], $css_var[1] );` 

However within the same loop the same css var strings are generated again and again but this time `$val` returns just "1" and overwrites the before set correct string parts with empty string.
So what happens here is that as `$val` is not an array, the "else" just uses the other setter for two arguments:
`$this->vars[ $css_var[0] ] = str_replace( '$', $val, $css_var[1] );`

I didn't deep dive into related functions too much and that fixed it for me at the moment. However I hope it helps and you can have a look to it. 

Thank you - @aristath - for the amazing work and best regards,

Philipp





